### PR TITLE
Ensure Compatibility with Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php-opencloud/openstack": "^3.0",
-        "illuminate/cache": "^5.1|^6.0"
+        "illuminate/cache": "^5.1|^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
In order to work with new Laravel 7 installations, the `illuminate/cache` package needs to be accepted in Version 7 as well. Therefore this pull requests adds this version to the possible required versions within the composer.json.

The caching implementation didn't change from Laravel 6 to 7, so there shouldn't be any compatibility issues. In addition I've tested it and everything works as intended.